### PR TITLE
Feat/plot image attacments to notebooks and error count tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ This project aims to automate the process of running and documenting the results
 
 9. Another Note for `Mac` users, once you start any of the scripts. Kindly go back and select the chrome browser to put it into focus.
 
-10. Always keep the browser zoom level at the default, **(100%)**, because any other level would affect the accuracy of plot images that the script snaps and saves, especially when running script for ChatGPT. 
+10. Always keep the browser zoom level at the default, **(100%)**, because any other level would affect the accuracy of plot images that the script snaps and saves, especially when running script for ChatGPT.
+
+11. You can find more details like the raw `response` generated and the count of `errors` observed in each turn/prompt inside the `time-tracksheet/` directory. For each turn/prompt, the count of errors will be the number of errors observed in the current prompt plus the total count from all previous prompts/turns combined, So if you have 3 queries and you see error counts on the row for prompt 3 when that prompt never encountered an error, it just means those counts represents the ones captured from the previous turns plus the ones captured in the current turn (which is zero in this case). Or to summarize everything, the error counts for the last prompt of each conversation is what you want to use in the Tracker Google sheet.
+
 
 **NOTE:** _Completely minimize mouse interactions to ensure a smooth process while the script is/are running as the script will mostly use the keyboard to type the file path when uploading files. If you're using the mouse elsewhere, the keyboard, will attempt to type the path of the file at wherever you focused the mouse instead of the web file input form popup. As it stands, both Gemini and GPT platforms don't make it possible to upload files using automated scripts, that's why I had to resort to the use of keyboard, in case you were wondering why. :)_
 
@@ -151,7 +154,6 @@ Once Chrome is running in debug mode and you are logged into Gemini:
 1. Place your `jobs.json` file in the script directory.
 2. Run the script to start the automation process.
 4. All various notebooks generated will be located in a directory called `notebooks/`.
-5. You can find more details like the raw `response` generated for each turn/prompt in the `time-tracksheet/` directory.
 
 #
 # CLI Based Reproducibility Frequency out of 5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Automation Script for Running and Documenting Prompts v2.3.1
+# Automation Script for Running and Documenting Prompts v2.4.1
 
 This project aims to automate the process of running and documenting the results of various prompts and storing them into notebooks. 
 
@@ -74,6 +74,8 @@ This project aims to automate the process of running and documenting the results
 8. From my personal experience, if your computer's screen is not big enough to have the 2 Chrome browser windows opened at maximum width side by side, you're better off executing the scripts one at a time so one brower can have enough space. This is so the 2 browsers don't overlap each other and mistakenly start clicking items in the other browser. You can first run `chatgpt.py` and wait for it finish executing before you do same for `gemini.py` or vice-versa. :)
 
 9. Another Note for `Mac` users, once you start any of the scripts. Kindly go back and select the chrome browser to put it into focus.
+
+10. Always keep the browser zoom level at the default, **(100%)**, because any other level would affect the accuracy of plot images that the script snaps and saves, especially when running script for ChatGPT. 
 
 **NOTE:** _Completely minimize mouse interactions to ensure a smooth process while the script is/are running as the script will mostly use the keyboard to type the file path when uploading files. If you're using the mouse elsewhere, the keyboard, will attempt to type the path of the file at wherever you focused the mouse instead of the web file input form popup. As it stands, both Gemini and GPT platforms don't make it possible to upload files using automated scripts, that's why I had to resort to the use of keyboard, in case you were wondering why. :)_
 
@@ -158,7 +160,7 @@ This also another automated script for running tasks/prompts through cli 5 times
 
 ## Configuration
 
-Create a `reproducible-jobs.json` file in the script's directory with the structure below. You will be populating this file with your various prompts your're trying to run 5 times. The `cbrfo5.py` script file will be reading your inputs that json file:
+Create a `reproducible-jobs.json` file in the script's directory with the same structure as `jobs.json` above. You will be populating this file with your various prompts your're trying to run/test 5 times. The `cbrfo5.py` script file will be reading your inputs that json file:
 
 **reproducible-jobs.json**
 ```python
@@ -171,7 +173,12 @@ Create a `reproducible-jobs.json` file in the script's directory with the struct
             # So currently you won't be uploading different files per turn, all will be 
             # combined and uploaded at the very beginning of the chat session.
             "files": [
-                "relative_file_path_1",
+                {
+                    # Relative path of file or dataset which you will be using for these prompts. 
+                    "path": "relative_file_path_1", #Ex: "query_files/activities.csv"
+                    # The google drive link to the file or dataset
+                    "url": "https://url_of_file"
+                },
                 # ...
             ],
             "prompts": [
@@ -187,8 +194,14 @@ Create a `reproducible-jobs.json` file in the script's directory with the struct
             # So currently you won't be uploading different files per turn, all will be 
             # combined and uploaded at the very beginning of the chat session.
             "files": [
-                "relative_file_path_1",
-                "relative_file_path_2"
+                {
+                    "path": "relative_file_path_1",
+                    "url": "https://url_of_file"
+                },
+                {
+                    "path": "relative_file_path_2",
+                    "url": "https://url_of_file"
+                }
                 # ...
             ],
             "prompts": [

--- a/gemini.py
+++ b/gemini.py
@@ -21,7 +21,7 @@ from pynput.keyboard import Key as PyKey, Controller
 from pprint import pprint
 
 from bake_notebook import IPYNBGenerator
-from utils import LastFooterElement, TextInLastElement, GeminiSpecificTextInLastElement, append_to_excel, ensure_directory_exists, update_error_code_counts, update_prompt_output
+from utils import LastFooterElement, TextInLastElement, GeminiSpecificTextInLastElement, append_to_excel, ensure_directory_exists, replace_json_tags, update_error_code_counts, update_prompt_output
 
 ''' SAMPLE `jobs.json` file template
 {
@@ -324,7 +324,17 @@ for task in JOBS['tasks']:
                 ERROR_COUNTS_DICT,
                 tracebacks_str
             )
-            
+
+            # Perform the insertion of plot images into notebook string
+            notebook_response = replace_json_tags(
+                notebook_str=notebook_response,
+                base64_images=[
+                    img.get_attribute('src').split('base64,')[1] if 'base64,' in img.get_attribute('src')\
+                    else img.get_attribute('src')\
+                    for img in plot_images
+                ]
+            )
+
             # Update the local backup data with latest prompt data if already exists, else add as new
             update_prompt_output(
                 main_dict       = OUTPUT,

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import pandas as pd
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -124,4 +125,15 @@ class LastFooterElement:
             footer_element = parent_element.find_element(By.XPATH, f"following-sibling::div[contains(@class, '{self.footer_class}')]")
             return footer_element
         return False
+
+def update_error_code_counts(error_counts_dict, string):
+    # Define the error types to count
+    error_types = [
+        'ModuleNotFoundError',
+        'FileNotFoundError', 'KeyError', 'ValueError', 'TypeError', 'AttributeError', 
+        'NameError', 'SyntaxError'
+    ]
+
+    for errorType in error_types:
+        error_counts_dict[errorType] += string.count(f"{errorType}:")
 

--- a/utils.py
+++ b/utils.py
@@ -137,3 +137,18 @@ def update_error_code_counts(error_counts_dict, string):
     for errorType in error_types:
         error_counts_dict[errorType] += string.count(f"{errorType}:")
 
+def replace_json_tags(notebook_str, base64_images):
+    ''' Inserts images (in base 64 format) underneath altair json tags in the notebook string'''
+    pattern = r"\[json-tag: code-generated-json-[^]]+\]"
+    counter = 0
+
+    def replacement_func(match):
+        nonlocal counter
+        replacement_text = f"{match.group(0)}"
+        if counter < len(base64_images):
+            replacement_text = f"![Plot {counter}](data:image/png;base64,{base64_images[counter]})\n{match.group(0)}"
+        counter += 1
+        return replacement_text
+
+    return re.sub(pattern, replacement_func, notebook_str)
+

--- a/utils.py
+++ b/utils.py
@@ -139,7 +139,7 @@ def update_error_code_counts(error_counts_dict, string):
 
 def replace_json_tags(notebook_str, base64_images):
     ''' Inserts images (in base 64 format) underneath altair json tags in the notebook string'''
-    pattern = r"\[json-tag: code-generated-json-[^]]+\]"
+    pattern = r"\[json-tag: [^]]+\]"
     counter = 0
 
     def replacement_func(match):


### PR DESCRIPTION
1. Adding plot images directly into notebooks as attachments to skip you having to add plot links manually every time.
2. Counting / keeping track of all error counts observed.
3. Using one json structure for `jobs.json` and `reproducible-jobs.json files`. You no longer have to change the "files" field value every time.
4. Added a few more waiting times with respect to users with low bandwidth.
5. Repeated list items bug in chatgpt script fixed
6. Improved a few more things in generated notebooks. 